### PR TITLE
Fix go-musicfox/go-musicfox#219

### DIFF
--- a/model/main.go
+++ b/model/main.go
@@ -118,9 +118,32 @@ func (m *Main) Update(msg tea.Msg, a *App) (Page, tea.Cmd) {
 
 		// menu start col, row
 		m.menuStartRow = msg.Height / 3
+		// If dynamic row count is on, we want at most 6 rows at the start to give more space to the entries
+		if m.options.DynamicRowCount && m.menuStartRow > 6 {
+			m.menuStartRow = 6
+		}
+
 		if !m.options.WhetherDisplayTitle && m.menuStartRow > 1 {
 			m.menuStartRow--
 		}
+
+		if m.options.DynamicRowCount {
+			var numColumns = 1
+			if m.isDualColumn {
+				numColumns = 2
+			}
+			// Compute the maximum number of entries per page based on the number of rows remaining.
+			// 11 is the magic number that works best.
+			// 3 lines for search + 5 lines of lyrics + 4 lines of song name and progress bar = 12. Not
+			// sure where the discrepancy comes from.
+			var maxEntries = (msg.Height - m.menuStartRow - 11) * numColumns
+			if maxEntries > 10 {
+				m.menuPageSize = maxEntries
+			} else {
+				m.menuPageSize = 10
+			}
+		}
+
 		if m.isDualColumn {
 			m.menuStartColumn = (msg.Width - 60) / 2
 			m.menuBottomRow = m.menuStartRow + int(math.Ceil(float64(m.menuPageSize)/2)) + 1 // 1 for search bar

--- a/model/options.go
+++ b/model/options.go
@@ -16,6 +16,7 @@ type Options struct {
 	LoadingText         string
 	PrimaryColor        string
 	DualColumn          bool // The menu list is displayed as a dual column
+	DynamicRowCount     bool // If true, the number of entries per page can be greater than 10
 	HideMenu            bool
 
 	TeaOptions []tea.ProgramOption // Tea program options
@@ -64,6 +65,7 @@ func DefaultOptions() *Options {
 		},
 		WhetherDisplayTitle: true,
 		DualColumn:          true,
+		DynamicRowCount:     false,
 		AppName:             util.PkgName,
 		LoadingText:         util.LoadingText,
 		PrimaryColor:        util.RandomColor,
@@ -92,4 +94,3 @@ func WithGlobalKeyHandlers(m map[string]GlobalKeyHandler) WithOption {
 		options.GlobalKeyHandlers = m
 	}
 }
-


### PR DESCRIPTION
增加了一个动态行数的选项。如果终端窗口足够高，则在一页中显示更多内容以填满空白。

只用默认设置测试过，但是只要其它设置不大幅改变行数应该就没问题。