### PR TITLE
调整打开DynamicRowCount后的一些行为

### DIFF
--- a/model/main.go
+++ b/model/main.go
@@ -359,6 +359,9 @@ func (m *Main) MenuList() []MenuItem {
 
 func (m *Main) menuListView(a *App, top *int) string {
 	var menuListBuilder strings.Builder
+	if m.options.DynamicRowCount {
+		m.menuCurPage = m.selectedIndex/m.menuPageSize + 1
+	}
 	menus := m.getCurPageMenus()
 	var lines, maxLines int
 	if m.isDualColumn {

--- a/model/main.go
+++ b/model/main.go
@@ -118,9 +118,23 @@ func (m *Main) Update(msg tea.Msg, a *App) (Page, tea.Cmd) {
 
 		// menu start col, row
 		m.menuStartRow = msg.Height / 3
-		// If dynamic row count is on, we want at most 10 rows at the start to give more space to the entries
-		if m.options.DynamicRowCount && m.menuStartRow > 10 {
-			m.menuStartRow = 10
+
+		// Height of the bottom part of the music player. Used in calculating the number of rows left.
+		// 3 lines for search + 5 lines of lyrics + 6 lines of song name and progress bar = 14. But somehow
+		// 13 works better.
+		bottomHeight := 13
+		numColumns := 1
+		if m.isDualColumn {
+			numColumns = 2
+		}
+		// If dynamic row count is on, we may want to adjust menuStartRow
+		if m.options.DynamicRowCount {
+			if m.options.MaxMenuStartRow > 0 {
+				// Limit menuStartRow to user-defined value
+				if m.menuStartRow > m.options.MaxMenuStartRow {
+					m.menuStartRow = m.options.MaxMenuStartRow
+				}
+			}
 		}
 
 		if !m.options.WhetherDisplayTitle && m.menuStartRow > 1 {
@@ -128,15 +142,8 @@ func (m *Main) Update(msg tea.Msg, a *App) (Page, tea.Cmd) {
 		}
 
 		if m.options.DynamicRowCount {
-			numColumns := 1
-			if m.isDualColumn {
-				numColumns = 2
-			}
 			// Compute the maximum number of entries per page based on the number of rows remaining.
-			// 13 is the magic number that works best.
-			// 3 lines for search + 5 lines of lyrics + 6 lines of song name and progress bar = 14. Not
-			// sure where the discrepancy comes from.
-			maxEntries := (msg.Height - m.menuStartRow - 13) * numColumns
+			maxEntries := (msg.Height - m.menuStartRow - bottomHeight) * numColumns
 			if maxEntries > 10 {
 				m.menuPageSize = maxEntries
 			} else {

--- a/model/options.go
+++ b/model/options.go
@@ -17,6 +17,7 @@ type Options struct {
 	PrimaryColor        string
 	DualColumn          bool // The menu list is displayed as a dual column
 	DynamicRowCount     bool // If true, the number of entries per page can be greater than 10
+	MaxMenuStartRow     int  // Max number of rows occupied by the title section before the menu. Works only when DynamicRowCount is on.
 	HideMenu            bool
 
 	TeaOptions []tea.ProgramOption // Tea program options
@@ -66,6 +67,7 @@ func DefaultOptions() *Options {
 		WhetherDisplayTitle: true,
 		DualColumn:          true,
 		DynamicRowCount:     false,
+		MaxMenuStartRow:     0,
 		AppName:             util.PkgName,
 		LoadingText:         util.LoadingText,
 		PrimaryColor:        util.RandomColor,


### PR DESCRIPTION
一共两个commit。

第一个修复了go-musicfox/go-musicfox#338。如果`menuPageSize`发生了改变，`menuCurPage`会被重新计算以保证当前选中的歌曲（`selectedIndex`）始终保持在当前页面。

第二个修改了顶部的空行。之前的设定导致标题上方和下方的空行数不一致，看着难受。改完之后上下都是两行。

![image](https://github.com/user-attachments/assets/df441f91-5f0b-42ac-a2d1-71fcd49894e7)
![image](https://github.com/user-attachments/assets/cc324222-731e-44e5-8268-24f5101073cb)
